### PR TITLE
Safely handle closed Kubernetes resource event streams

### DIFF
--- a/pkg/node/sync/local_node_sync.go
+++ b/pkg/node/sync/local_node_sync.go
@@ -181,7 +181,10 @@ func (ini *localNodeSynchronizer) getK8sLocalCiliumNode(ctx context.Context) *v2
 	select {
 	case <-ctx.Done():
 		return nil
-	case ev := <-ini.K8sCiliumLocalNode.Events(ctx):
+	case ev, ok := <-ini.K8sCiliumLocalNode.Events(ctx):
+		if !ok {
+			return nil
+		}
 		ev.Done(nil)
 		switch ev.Kind {
 		case resource.Upsert:

--- a/pkg/node/sync/local_node_sync_test.go
+++ b/pkg/node/sync/local_node_sync_test.go
@@ -30,7 +30,8 @@ import (
 
 // Mock resources for testing
 type mockResource[T k8sRuntime.Object] struct {
-	items []resource.Event[T]
+	items            []resource.Event[T]
+	closeImmediately bool
 }
 
 func (mr *mockResource[T]) Observe(ctx context.Context, next func(resource.Event[T]), complete func(error)) {
@@ -42,6 +43,10 @@ func (mr *mockResource[T]) Events(ctx context.Context, opts ...resource.EventsOp
 	for _, item := range mr.items {
 		ch <- item
 	}
+	if mr.closeImmediately {
+		close(ch)
+		return ch
+	}
 	// Keep channel open until context is cancelled to simulate blocking behavior
 	go func() {
 		<-ctx.Done()
@@ -52,6 +57,21 @@ func (mr *mockResource[T]) Events(ctx context.Context, opts ...resource.EventsOp
 
 func (mr *mockResource[T]) Store(context.Context) (resource.Store[T], error) {
 	panic("store not impl")
+}
+
+func TestGetK8sLocalCiliumNodeClosedEvents(t *testing.T) {
+	sync := &localNodeSynchronizer{
+		localNodeSynchronizerParams: localNodeSynchronizerParams{
+			Logger: hivetest.Logger(t),
+			K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{
+				closeImmediately: true,
+			},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		require.Nil(t, sync.getK8sLocalCiliumNode(context.Background()))
+	})
 }
 
 type fakeLocalNode struct {


### PR DESCRIPTION
context is not normally canceled during a successful startup. It is canceled only when Hive aborts or stops that startup operation.

  In this path, InitLocalNode receives Hive’s lifecycle startup context. getK8sLocalCiliumNode derives its own child context from it and passes that child context to
  Events(ctx). The resource implementation explicitly closes its event channel when that context is canceled.

```
    ctx, cancel := context.WithCancel(ctx)
    defer cancel()
    select {
    case <-ctx.Done():   《--- may enter here when ctx is canceld
        return nil
    case ev, ok := <-ini.K8sCiliumLocalNode.Events(ctx):  《--- may enter here when ctx is canceld 
        if !ok {
            return nil
        }
        ev.Done(nil)    《---- ev.Done may be a nil


```

  Cancellation can occur when startup is interrupted, such as:

  - cilium-agent is terminated while still starting, for example during a DaemonSet rollout, Pod deletion, node shutdown, or eviction;
  - another Hive startup hook fails, causing Hive to abort startup;
  - startup is canceled by its parent lifecycle context.

  The issue is therefore a shutdown/aborted-startup race: both ctx.Done() and the closed event channel become ready. The original select can choose the event-channel
  branch, receive a zero-value event, and call its nil Done callback.